### PR TITLE
Added callback in the Omnibar to report the current scene.  

### DIFF
--- a/dashboard/elements/gdq-checklist/gdq-checklist.js
+++ b/dashboard/elements/gdq-checklist/gdq-checklist.js
@@ -17,6 +17,7 @@
 				this.techStationDuties = newVal.techStationDuties;
 				this.otherDuties = newVal.otherDuties;
 			});
+
 		},
 
 		_checkboxChanged(e) {

--- a/extension/checklist.js
+++ b/extension/checklist.js
@@ -28,9 +28,20 @@ module.exports = function (nodecg) {
 			{name: 'Steam Notifications Off', complete: false}
 		]
 	};
-
 	// Instantiate replicant with defaults object, which will load if no persisted data is present.
 	const checklist = nodecg.Replicant('checklist', {defaultValue: checklistDefault});
+
+	nodecg.listenFor('sceneChange', function(data){
+		nodecg.log.info("Listener hit!");
+		console.log("Test! " + data);
+		if(nodecg.bundleConfig.checklist && nodecg.bundleConfig.checklist[data]){
+			nodecg.log.info("Listener hit!");
+			checklist.value = nodecg.bundleConfig.checklist[data];
+		} else {
+			nodecg.log.info("No checklist value found.");
+			checklist.value = checklistDefault;
+		}
+	});
 
 	// Reconcile differences between persisted value and what we expect the checklistDefault to be.
 	const persistedValue = checklist.value;

--- a/graphics/components/gdq-omnibar/gdq-omnibar.js
+++ b/graphics/components/gdq-omnibar/gdq-omnibar.js
@@ -56,6 +56,19 @@
 
 			// CTA is the first thing we show, so we use this to start our loop
 			this.showCTA();
+
+			nodecg.log.info("Registering scene change");
+			//If this is loaded in OBS Studio, register the scene change callback
+			if(window.obsstudio){
+				nodecg.log.info("OBS Found");
+				window.obsstudio.onSceneChange = function(sceneName) {
+					nodecg.sendMessage("sceneChange", sceneName);
+				};
+			} else {
+				nodecg.log.info("OBS Not Found!");
+				nodecg.sendMessage("sceneChange", null);
+				console.log("OBS Studio not detected.");
+			}
 		},
 
 		totalChanged(newVal) {


### PR DESCRIPTION
This is then used to populate the checklist in the dashboard.

Here is an example of the JSON snippet to add to the mm5-layouts.json file:

    "checklist": {
		"Base-Omnibar" : {
			"extraContent":[],
			"techStationDuties":[
				{"name":"Prepare to Stream", "complete":false}
			],
			"otherDuties":[
				{"name":"Get games ready", "complete":false}
			]
		},
		"Widescreen One" : {
			"extraContent":[
				{"name":"Check for Advertisement", "complete":false},
				{"name":"Check for Interview", "complete":false},
				{"name":"Check for Super Nintendo", "complete":false}
			],
			"techStationDuties":[
				{"name":"Reset Timer", "complete":false},
				{"name":"Stop/Start Recording", "complete":false}
			],
			"otherDuties":[
				{"name":"Cue Break Music", "complete":false},
				{"name":"Runner Game Audio", "complete":false}
			]
		},
		"Widescreen Two" : {
			"extraContent":[
				{"name":"Has extra content loaded", "complete":true}
			],
			"techStationDuties":[
				{"name":"Load video game", "complete":false},
				{"name":"Charge Megabusters!", "complete":true},
				{"name":"Get ready!", "complete":false}
			],
			"otherDuties":[
				{"name":"Cue Break Music", "complete":false},
				{"name":"Take Rush for a ride", "complete":false}
			]
		}
	}